### PR TITLE
Java 7 compatibility

### DIFF
--- a/openjdk/openjdk.build
+++ b/openjdk/openjdk.build
@@ -103,7 +103,7 @@
                 </replacetokens>
             </filterchain>
         </copy>
-        <exec program="javac" commandline="-J-Xmx1536M -g -nowarn -bootclasspath mscorlib.jar${pathsep}System.jar${pathsep}System.Core.jar${pathsep}System.Data.jar${pathsep}System.Drawing.jar${pathsep}IKVM.Runtime.jar @allsources.gen.lst" useruntimeengine="false" />
+        <exec program="javac" commandline="-J-Xmx1536M -target 1.6 -source 1.6 -g -nowarn -bootclasspath mscorlib.jar${pathsep}System.jar${pathsep}System.Core.jar${pathsep}System.Data.jar${pathsep}System.Drawing.jar${pathsep}IKVM.Runtime.jar @allsources.gen.lst" useruntimeengine="false" />
     </target>
 
     <target name="rmi">


### PR DESCRIPTION
The OpenJDK build didn't specify the Java version to target, needs to be 1.6 for IKVM. Fixed build script accordingly.
