### PR TITLE
Fix JNIEnv.FindClass

### DIFF
--- a/runtime/JniInterface.cs
+++ b/runtime/JniInterface.cs
@@ -1317,8 +1317,7 @@ namespace IKVM.Runtime
 			{
 				if(psz[i] == 0)
 				{
-					int oem = System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage;
-					return new String((sbyte*)psz, 0, i, Encoding.GetEncoding(oem));
+					return new String((sbyte*)psz, 0, i, Encoding.ASCII);
 				}
 			}
 		}


### PR DESCRIPTION
I was seeing this issue with FindClass:

```
May 22 15:57:43 Brunos-iPad arcadians[10034] <Warning>: Unhandled managed exception: CodePage 437 not supported (System.NotSupportedException)
          at System.Text.Encoding.GetEncoding (Int32 codepage) [0x00000] in <filename unknown>:0 
          at IKVM.Runtime.JNIEnv.StringFromOEM (System.Byte* psz) [0x00000] in <filename unknown>:0 
          at IKVM.Runtime.JNIEnv.FindClass (IKVM.Runtime.JNIEnv* pEnv, System.Byte* pszName) [0x00000] in <filename unknown>:0 
```

Not sure if assuming ascii is the right solution, but it fixes things for me.
